### PR TITLE
Adding support for DefaultAWSCredentialsProviderChain.

### DIFF
--- a/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
@@ -1,5 +1,6 @@
 package com.github.skhatri.s3aws.client
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Region
 import com.amazonaws.regions.Regions
@@ -16,7 +17,9 @@ public class S3Client {
     private static final String AMZ_REDIRECT_LINK = "x-amz-website-redirect-location";
 
     public S3Client(String awsProfile, String region) {
-        s3Client = new AmazonS3Client(new ProfileCredentialsProvider(awsProfile));
+        s3Client = "none".equals(awsProfile) ?
+            new AmazonS3Client(new DefaultAWSCredentialsProviderChain()) :
+            new AmazonS3Client(new ProfileCredentialsProvider(awsProfile));
         if (region != null && !"".equals(region)) {
             s3Client.setRegion(Region.getRegion(Regions.fromName(region)))
         }


### PR DESCRIPTION
This pull request adds support for AWS authentication via the `DefaultAWSCredentialsProviderChain`.

The original implementation that uses the `ProfileCredentialsProvider` has been left in place.

In order to trigger the plugin to use `DefaultAWSCredentialsProviderChain` the build can configure `awsProfile = 'none'`, otherwise the behavior remains exactly as before. I'm not entirely thrilled with this implementation, but in the interests of backward compatibility, this seemed the least objectionable option.

Let me know what you think. If you're ok with the implementation, I'd be happy to update the README file accordingly. If you'd like to see a different implementation, let me know!

Thanks,
Lance
