### PR TITLE
Use AWS SDK 1.11.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'signing'
 dependencies {
     compile localGroovy()
     compile gradleApi()
-    compile 'com.amazonaws:aws-java-sdk-s3:1.9.33'
+    compile 'com.amazonaws:aws-java-sdk-s3:1.11.82'
     compile 'joda-time:joda-time:2.4'
 }
 


### PR DESCRIPTION
Allows plugin to load credential chain from containers and other bug fixes.

The SDK is quite old and a number of enhancements have come along. For example in version 1.11.17 support for S3 to resolve a credential provider chain while in a container was added. https://aws.amazon.com/releasenotes/Java/1777722793416885

This fix will allow the gradle plugin to inherit credentials in AWS CodeBuild projects.