### PR TITLE
Optional metadata parameter for S3 upload

### DIFF
--- a/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
@@ -25,13 +25,18 @@ public class S3Client {
         }
     }
 
-    public String uploadFile(String bucketName, String key, String fileName, String link) {
+    public String uploadFile(String bucketName, String key, String fileName, String link, ObjectMetadata metadata) {
         try {
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, new File(fileName))
+
+            if (metadata != null) {
+                putObjectRequest.withMetadata(metadata)
+            }
+
             s3Client.putObject(putObjectRequest)
             String linkName = createLinkObject(link, key, bucketName)
             if (linkName == null) {
-                linkName = s3Client.generatePresignedUrl(bucketName, key, new LocalDateTime().plusDays(30).toDate())
+                linkName = s3Client.generatePresignedUrl(bucketName, key, new LocalDateTime().plusDays(7).toDate())
             }
             return linkName
         } catch (Exception e) {
@@ -48,7 +53,7 @@ public class S3Client {
             PutObjectRequest linkPutRequest = new PutObjectRequest(bucketName, link, inputStream, metadata)
             linkPutRequest.setCannedAcl(CannedAccessControlList.Private)
             s3Client.putObject(linkPutRequest);
-            return s3Client.generatePresignedUrl(bucketName, link, new LocalDateTime().plusDays(30).toDate());
+            return s3Client.generatePresignedUrl(bucketName, link, new LocalDateTime().plusDays(7).toDate());
         }
     }
 

--- a/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
@@ -25,12 +25,16 @@ public class S3Client {
         }
     }
 
-    public String uploadFile(String bucketName, String key, String fileName, String link, ObjectMetadata metadata) {
+    public String uploadFile(String bucketName, String key, String fileName, String link, ObjectMetadata metadata, CannedAccessControlList acl) {
         try {
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, new File(fileName))
 
             if (metadata != null) {
                 putObjectRequest.withMetadata(metadata)
+            }
+
+            if (acl != null) {
+                putObjectRequest.withCannedAcl(acl)
             }
 
             s3Client.putObject(putObjectRequest)

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3Plugin.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3Plugin.groovy
@@ -25,6 +25,7 @@ public class S3Plugin implements Plugin<Project> {
             conventionMapping.key = { s3UploadExt.key }
             conventionMapping.link = { s3UploadExt.link }
             conventionMapping.file = { s3UploadExt.file }
+            conventionMapping.metadata = { s3UploadExt.metadata }
         }
     }
 

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3Plugin.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3Plugin.groovy
@@ -23,9 +23,16 @@ public class S3Plugin implements Plugin<Project> {
             conventionMapping.bucket = { s3Ext.bucket }
             conventionMapping.awsProfile = { s3Ext.awsProfile }
             conventionMapping.key = { s3UploadExt.key }
-            conventionMapping.link = { s3UploadExt.link }
+            if (s3UploadExt.link) {
+                conventionMapping.link = { s3UploadExt.link }
+            }
             conventionMapping.file = { s3UploadExt.file }
-            conventionMapping.metadata = { s3UploadExt.metadata }
+            if (s3UploadExt.metadata) {
+                conventionMapping.metadata = { s3UploadExt.metadata }
+            }
+            if (s3UploadExt.acl) {
+                conventionMapping.acl = { s3UploadExt.acl }
+            }
         }
     }
 

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadExtension.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadExtension.groovy
@@ -1,9 +1,12 @@
 package com.github.skhatri.s3aws.plugin
 
+import com.amazonaws.services.s3.model.ObjectMetadata
+
 class S3UploadExtension {
     String bucket
     String awsProfile
     String key = ''
     String file = ''
     String link = ''
+    ObjectMetadata metadata = null
 }

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadExtension.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadExtension.groovy
@@ -1,5 +1,6 @@
 package com.github.skhatri.s3aws.plugin
 
+import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
 
 class S3UploadExtension {
@@ -9,4 +10,5 @@ class S3UploadExtension {
     String file = ''
     String link = ''
     ObjectMetadata metadata = null
+    CannedAccessControlList acl = null
 }

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
@@ -1,5 +1,6 @@
 package com.github.skhatri.s3aws.plugin
 
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.github.skhatri.s3aws.client.S3Client
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -19,11 +20,14 @@ class S3UploadTask extends DefaultTask {
     String file
     @Input
     String link
+    @Input
+    ObjectMetadata metadata
 
     public S3UploadTask() {
         bucket = ''
         region = ''
         awsProfile = ''
+        metadata = null;
     }
 
     @TaskAction
@@ -41,8 +45,8 @@ class S3UploadTask extends DefaultTask {
         }
         String keyValue = getKey()
         S3Client client = new S3Client(profileName, regionName)
-        String presigned = client.uploadFile(bucketName, keyValue, fileName, getLink())
+        String presigned = client.uploadFile(bucketName, keyValue, fileName, getLink(), metadata)
         logger.quiet "Uploaded \"" + fileName + "\" to \"" + keyValue + "\""
-        logger.quiet "Downloadable from " + presigned + " within next 30 days"
+        logger.quiet "Downloadable from " + presigned + " within next 7 days"
     }
 }

--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
@@ -1,9 +1,11 @@
 package com.github.skhatri.s3aws.plugin
 
+import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.github.skhatri.s3aws.client.S3Client
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 class S3UploadTask extends DefaultTask {
@@ -18,10 +20,12 @@ class S3UploadTask extends DefaultTask {
     String key
     @Input
     String file
-    @Input
+    @Input @Optional
     String link
-    @Input
+    @Input @Optional
     ObjectMetadata metadata
+    @Input @Optional
+    CannedAccessControlList acl
 
     public S3UploadTask() {
         bucket = ''
@@ -45,7 +49,7 @@ class S3UploadTask extends DefaultTask {
         }
         String keyValue = getKey()
         S3Client client = new S3Client(profileName, regionName)
-        String presigned = client.uploadFile(bucketName, keyValue, fileName, getLink(), metadata)
+        String presigned = client.uploadFile(bucketName, keyValue, fileName, getLink(), getMetadata(), getAcl())
         logger.quiet "Uploaded \"" + fileName + "\" to \"" + keyValue + "\""
         logger.quiet "Downloadable from " + presigned + " within next 7 days"
     }


### PR DESCRIPTION
This can be used to upload the MD5 of the file to later test the validity of a download without relying on a separate file.