### PR TITLE
change 'none' aws profile detection to an empty string

### DIFF
--- a/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/client/S3Client.groovy
@@ -17,7 +17,7 @@ public class S3Client {
     private static final String AMZ_REDIRECT_LINK = "x-amz-website-redirect-location";
 
     public S3Client(String awsProfile, String region) {
-        s3Client = "none".equals(awsProfile) ?
+        s3Client = "".equals(awsProfile) ?
             new AmazonS3Client(new DefaultAWSCredentialsProviderChain()) :
             new AmazonS3Client(new ProfileCredentialsProvider(awsProfile));
         if (region != null && !"".equals(region)) {


### PR DESCRIPTION
"none" might be someone's valid aws profile, meanwhile if we want to use DefaultAWSCredentialsProviderChain, I think it's better to set it to an empty string as it is not a valid aws profile. Furthermore, `region` is already using empty string detection, too