### PR TITLE
Make S3UploadTask compatible with Gradle 7

### DIFF
--- a/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
+++ b/src/main/groovy/com/github/skhatri/s3aws/plugin/S3UploadTask.groovy
@@ -10,11 +10,11 @@ import org.gradle.api.tasks.TaskAction
 
 class S3UploadTask extends DefaultTask {
 
-    @Input
+    @Input @Optional
     String bucket
-    @Input
+    @Input @Optional
     String region
-    @Input
+    @Input @Optional
     String awsProfile
     @Input
     String key


### PR DESCRIPTION
The `bucket` property is optional and might not have a value. It needs to be marked as such otherwise Gradle 7 will fail the build.
```
* What went wrong:
A problem was found with the configuration of task ':build-cache-deep-dive-maven:s3Upload' (type 'S3UploadTask').
  - In plugin 's3' type 'com.github.skhatri.s3aws.plugin.S3UploadTask' property 'bucket' doesn't have a configured value.

    Reason: This property isn't marked as optional and no value has been configured.

    Possible solutions:
      1. Assign a value to 'bucket'.
      2. Mark property 'bucket' as optional.

    Please refer to https://docs.gradle.org/7.1.1/userguide/validation_problems.html#value_not_set for more details about this problem.
```